### PR TITLE
fix: Add node preset to StackBlitz link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project was generated using [Nx](https://nx.dev).
 
 Preview the example live on [StackBlitz](http://stackblitz.com/):
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/nrwl/stackblitz-nx-angular)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/nrwl/stackblitz-nx-angular?preset=node)
 
 ## Quick Start & Documentation
 


### PR DESCRIPTION
Hey @brandonroberts 👋 !

We noticed that StackBlitz is falling back to a v1 project instead of using WebContainer when detecting an Angular project. By using `?preset=node` query parameter, it will use WebContainer.

We're also adding an additional check for `.stackblitzrc`.